### PR TITLE
Fix build failing with error: use of unstable library feature because rustc-serialize is deprecated

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ license = "MIT"
 
 [dependencies]
 lazy_static = "*"
+serde = { version = "1.0", features = ["derive"], optional = true}
 rustc-serialize = { version = "*", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "coordinates"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Mattis Marjak <mattis.marjak@gmail.com>"]
 license = "MIT"
 
 [dependencies]
-rustc-serialize = "*"
 lazy_static = "*"
+rustc-serialize = { version = "*", optional = true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,9 @@ extern crate lazy_static;
 #[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
 
+#[cfg(feature = "serde")]
+extern crate serde;
+
 mod structs;
 mod conversions;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,8 +26,12 @@
         trivial_casts, trivial_numeric_casts, unstable_features,
         unused_import_braces, unused_qualifications)]
 
+#![cfg_attr(feature = "rustc-serialize", warn(soft_unstable, deprecated))]
+        
 #[macro_use]
 extern crate lazy_static;
+
+#[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize;
 
 mod structs;

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -25,8 +25,11 @@
 use std::convert::From;
 use ::conversions::{ecef_to_lla, lla_to_ecef};
 
+#[cfg(feature="serde")]
+use serde::{Serialize, Deserialize};
 
 #[cfg_attr(feature="rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature="serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone)]
 pub struct LLA {
     pub lat_deg: f64,
@@ -62,6 +65,7 @@ impl<'a> From<&'a LLA> for LLA {
 
 
 #[cfg_attr(feature="rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[cfg_attr(feature="serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Copy, Clone)]
 pub struct ECEF {
     pub x: f64,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -26,7 +26,8 @@ use std::convert::From;
 use ::conversions::{ecef_to_lla, lla_to_ecef};
 
 
-#[derive(Debug, Copy, Clone, RustcEncodable, RustcDecodable)]
+#[cfg_attr(feature="rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[derive(Debug, Copy, Clone)]
 pub struct LLA {
     pub lat_deg: f64,
     pub lon_deg: f64,
@@ -60,7 +61,8 @@ impl<'a> From<&'a LLA> for LLA {
 }
 
 
-#[derive(Debug, Copy, Clone, RustcEncodable, RustcDecodable)]
+#[cfg_attr(feature="rustc-serialize", derive(RustcEncodable, RustcDecodable))]
+#[derive(Debug, Copy, Clone)]
 pub struct ECEF {
     pub x: f64,
     pub y: f64,


### PR DESCRIPTION
rustc-serialize is deprecated and currently causes the build to fail due to "error: use of unstable library feature 'rustc_encodable_decodable' (`#[deny(soft_unstable)]` on by default)."

This PR adds two features:
- `rustc-serialize`, which will continue to work for the time being, but build with warnings and eventually become a hard error
- `serde`, which is the recommended alternative for rustc-serialize

This allows downstream packages depending on the `rustc-serialize`-functionality to continue using them, while allowing them to upgrade to `serde`. Packages which do not depend on any de-/serialization functionality should not experience any changes, other than no longer depending on `rustc-serialize`.